### PR TITLE
fixed compiler path being incorrect for newer versions of typescript

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var vm = require('vm');
 var fs = require('fs');
 var path = require('path');
 
-var tsc = require.resolve("typescript").replace(/typescript\.js$/, "tsc.js");
+var tsc = path.join(path.dirname(require.resolve("typescript")),"tsc.js");
 var tscScript = vm.createScript(fs.readFileSync(tsc, "utf8"), tsc);
 var libPath = path.join(path.dirname(require.resolve("typescript")), "lib.d.ts")
 


### PR DESCRIPTION
It turns out for typescript 1.4 the module resolves to typescriptServices.js, not typescript.js as expected. This causes the compiler path to be set incorrectly (As seen in eknkc/typescript-require#26). This patch fixes the problem in a backwards compatible way.