### PR TITLE
Keep relative paths to the compiled files in tmp/

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,8 @@ function isModified(tsname, jsname) {
 function compileTS (module) {
   var exitCode = 0;
   var tmpDir = path.join(process.cwd(), "tmp", "tsreq");
-  var jsname = path.join(tmpDir, path.basename(module.filename, ".ts") + ".js");
+  var relativePath = path.relative(process.cwd(), module.filename);
+  var jsname = path.join(tmpDir, path.dirname(relativePath), path.basename(module.filename, ".ts") + ".js");
 
   if (!isModified(module.filename, jsname)) {
     return jsname;


### PR DESCRIPTION
I have `typescript-require@0.2.8` installed on Mac OS X 10.10.2 and `parser-spec.ts` is located at `./test/` dir. When I had tried to run:
    ./node_modules/.bin/mocha --compilers ts:typescript-require

I ran into the problem 

    [nikolay: ~/Desktop/project ] $ ./node_modules/.bin/mocha --compilers ts:typescript-require
    /Users/nikolay/Desktop/project/tmp/tsreq

    fs.js:438
      return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                     ^
    Error: ENOENT, no such file or directory '/Users/nikolay/Desktop/project/tmp/tsreq/parser-spec.js'
        at Object.fs.openSync (fs.js:438:18)
        at Object.fs.readFileSync (fs.js:289:15)
        at runJS (/Users/nikolay/Desktop/project/node_modules/typescript-require/index.js:96:20)
        at Object.require.extensions..ts (/Users/nikolay/Desktop/project/node_modules/typescript-require/index.js:22:3)
        at Module.load (module.js:356:32)
        at Function.Module._load (module.js:312:12)
        at Module.require (module.js:364:17)
        at require (module.js:380:17)
        at /Users/nikolay/Desktop/project/node_modules/mocha/lib/mocha.js:185:27
        at Array.forEach (native)
        at Mocha.loadFiles (/Users/nikolay/Desktop/project/node_modules/mocha/lib/mocha.js:182:14)
        at Mocha.run (/Users/nikolay/Desktop/project/node_modules/mocha/lib/mocha.js:394:31)
        at Object.<anonymous> (/Users/nikolay/Desktop/project/node_modules/mocha/bin/_mocha:394:16)

It seems that typescript-require compiles to a file disregarding for the path structure. This fix is intended to fill the gap.